### PR TITLE
feat: add endpoints for tags

### DIFF
--- a/src/db-service.ts
+++ b/src/db-service.ts
@@ -200,4 +200,44 @@ export class CategoryService {
       .then(({ rows }) => rows[0] || null);
   }
 
+  /* queries related to customized tags */
+
+   // get customized tags of given item
+   async getSettings(
+    id: string,
+    dbHandler: TrxHandler,
+  ): Promise<JSON> {
+    return (
+      dbHandler
+        .query<JSON>(
+          sql`
+        SELECT settings
+        FROM item
+        WHERE id = ${id}
+        `,
+          )
+        .then(({ rows }) => rows[0] || null)
+    );
+  } 
+
+   // update customized tags
+   async updateSettings(
+    settings: string,
+    id: string,
+    dbHandler: TrxHandler,
+  ): Promise<string> {
+    return (
+      dbHandler
+        .query<string>(
+          sql`
+          UPDATE item
+          SET settings = ${settings}
+          WHERE id = ${id}
+          RETURNING settings
+        `,
+          )
+        .then(({ rows }) => rows[0] || null)
+    );
+  } 
+
 }

--- a/src/interfaces/customized-tags.ts
+++ b/src/interfaces/customized-tags.ts
@@ -1,0 +1,3 @@
+export interface CustomizedTags{
+    values: string[];
+}

--- a/src/service-api.ts
+++ b/src/service-api.ts
@@ -3,6 +3,7 @@ import { FastifyPluginAsync } from 'fastify';
 
 // local
 import { CategoryService } from './db-service';
+import { CustomizedTags } from './interfaces/customized-tags';
 import { ItemCategory } from './interfaces/item-category';
 import common, { create, getOne } from './schemas';
 import { TaskManager } from './task-manager';
@@ -82,6 +83,26 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         return runner.runSingle(task, log);
       },
     );  
+
+    /* customized tags endpoints */
+    // get customized tags
+    fastify.get<{ Params: {itemId: string };}>(
+      '/:itemId/customized-tags',
+      async ({ member, params: {itemId}, log }) => {
+        const task = taskManager.createGetCustomizedTagsTask(member, itemId);
+        return runner.runSingle(task, log);
+      },
+    );
+
+    // update customized tags
+    fastify.post<{ Params: {itemId: string }; Body: CustomizedTags}>(
+      '/:itemId/customized-tags',
+      async ({ member, params: {itemId}, body, log }) => {
+        const task = taskManager.createUpdateCustomizedTagsTask(member, body, itemId);
+        return runner.runSingle(task, log);
+      },
+    );
+
 };
 
 export default plugin;

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -11,6 +11,9 @@ import { GetCategoryTypesTask } from './tasks/get-types-task';
 import { CreateItemCategoryTask } from './tasks/create-item-category-task';
 import { DeleteItemCategoryTask } from './tasks/delete-item-category-task';
 import { GetItemsByCategoryTask } from './tasks/get-items-by-category-task';
+import { GetCustomizedTagsTask } from './tasks/get-customized-tags-task';
+import { UpdateCustomizedTagsTask } from './tasks/update-customized-tags-task';
+import { CustomizedTags } from './interfaces/customized-tags';
 
 export class TaskManager implements CategoryTaskManager {
   private categoryService: CategoryService;
@@ -21,7 +24,7 @@ export class TaskManager implements CategoryTaskManager {
     this.itemService = this.itemService;
   }
 
-  // CRUD
+  // category
   getGetCategoriesByTypeTaskName(): string { return GetCategoriesByTypeTask.name; }
   getGetCategoryTypesTaskName(): string { return GetCategoryTypesTask.name; }
   getGetCategoryTaskName(): string { return GetCategoryTask.name; }
@@ -29,9 +32,13 @@ export class TaskManager implements CategoryTaskManager {
   getGetItemCategoryTaskName(): string { return GetItemCategoryTask.name; }
   getCreateItemCategoryTaskName(): string { return CreateItemCategoryTask.name; }
   getDeleteItemCategoryTaskName(): string { return DeleteItemCategoryTask.name; }
+
+  //customized tags
+  getGetCustomizedTagsTaskName(): string { return GetCustomizedTagsTask.name; }
+  getCreateCustomizedTagsTaskName(): string { return UpdateCustomizedTagsTask.name; }
   
 
-  // CRUD
+  // category
   createGetCategoryTask(member: Member, categoryId: string): GetCategoryTask {
     return new GetCategoryTask({categoryId: categoryId}, member, this.categoryService);
   }
@@ -58,5 +65,14 @@ export class TaskManager implements CategoryTaskManager {
 
   createDeleteItemCategoryTask(member: Member, entryId: string): DeleteItemCategoryTask{
     return new DeleteItemCategoryTask({entryId: entryId}, member, this.categoryService);
+  }
+
+  // customized tags
+  createGetCustomizedTagsTask(member: Member, itemId: string): GetCustomizedTagsTask {
+    return new GetCustomizedTagsTask({itemId: itemId} ,member, this.categoryService);
+  }
+
+  createUpdateCustomizedTagsTask(member: Member, data: CustomizedTags, itemId: string): UpdateCustomizedTagsTask {
+    return new UpdateCustomizedTagsTask({itemId: itemId, data: data} ,member, this.categoryService);
   }
 }

--- a/src/tasks/get-customized-tags-task.ts
+++ b/src/tasks/get-customized-tags-task.ts
@@ -1,0 +1,33 @@
+// global
+import { DatabaseTransactionHandler, Member } from 'graasp'
+// local
+import { CategoryService } from '../db-service';
+import { BaseCategoryTask } from './base-category-task';
+
+type InputType = { itemId?: string };
+
+export class GetCustomizedTagsTask extends BaseCategoryTask<string[]> {
+  input: InputType;
+  getInput: () => InputType;
+
+  get name(): string {
+    return GetCustomizedTagsTask.name;
+  }
+
+  constructor(input: InputType, member: Member, categoryService: CategoryService) {
+    super(member, categoryService);
+    this.input = input ?? {};
+  }
+
+  async run(handler: DatabaseTransactionHandler): Promise<void> {
+    this.status = 'RUNNING';
+
+    const { itemId } = this.input;
+    const settings = await this.categoryService.getSettings(itemId, handler);
+    const settingValues = settings['settings'];
+
+
+    this.status = 'OK';
+    this._result = settingValues['tags'] || [];
+  }
+}

--- a/src/tasks/update-customized-tags-task.ts
+++ b/src/tasks/update-customized-tags-task.ts
@@ -1,0 +1,37 @@
+// global
+import { FastifyLoggerInstance } from 'fastify';
+import { DatabaseTransactionHandler} from 'graasp';
+// other services
+import { Member } from 'graasp';
+// local
+import { CategoryService } from '../db-service';
+import { CustomizedTags } from '../interfaces/customized-tags';
+import { BaseCategoryTask } from './base-category-task';
+
+type InputType = { itemId?: string, data?: CustomizedTags };
+
+export class UpdateCustomizedTagsTask extends BaseCategoryTask<string> {
+  input: InputType;
+  getInput: () => InputType;
+
+  get name(): string { return UpdateCustomizedTagsTask.name; }
+
+  constructor(input: InputType, member: Member, CategoryService: CategoryService) {
+    super(member, CategoryService);
+    this.input = input ?? {};
+  }
+
+  async run(handler: DatabaseTransactionHandler, log: FastifyLoggerInstance): Promise<void> {
+    this.status = 'RUNNING';
+
+    // get settings 
+    const settings =await this.categoryService.getSettings(this.input.itemId, handler);
+    const { itemId, data } = this.input;
+    settings['settings']['tags'] = data.values;
+    const newSettings = JSON.stringify(settings['settings']);
+
+    // update tags value in settings
+    this._result = await this.categoryService.updateSettings(newSettings, itemId, handler);
+    this.status = 'OK';
+  }
+}


### PR DESCRIPTION
close #6 
Added endpoints for customized (user-defined) tags
Two new endpoints: GET & POST + {host}/items/:itemId/customized-tags
The two endpoints get and update customized tags of given item respectively.
Customized Tags are stored within **settings** column of **item** table